### PR TITLE
Simplified pagination logic

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -475,9 +475,8 @@ def DirectoryList(title, href, page):
 
     if nextpg_node:
         href = nextpg_node[0].get('href')
-        nextpg = int(href.split('/')[-2])
         oc.add(NextPageObject(
-            key=Callback(DirectoryList, title=title, href=href, page=nextpg),
+            key=Callback(DirectoryList, title=title, href=href, page=page+1),
             title='Next Page>>'))
 
     return oc


### PR DESCRIPTION
Simplified the pagination logic in DirectoryList. Instead of extracting the next page value from the URL, now it just increments the page number by 1. The reason for this change is that this plugin was choking on porn star pages, because they have a different format for page values in the URL. Porn star pages have a simple query string, while other pages have a "friendly URL" style (e.g. /1a/pornstar/riley+reid?sort=new&page=2 vs /trending_videos/2/).
